### PR TITLE
Fix short address decoding

### DIFF
--- a/contracts/common/RLP.sol
+++ b/contracts/common/RLP.sol
@@ -74,10 +74,7 @@ library RLP {
         pure
         returns (address data)
     {
-        (uint rStartPos,) = _decode(self);
-        assembly {
-            data := div(mload(rStartPos), exp(256, 12))
-        }
+        return address(toUint(self));
     }
 
     /// @dev Create an iterator.


### PR DESCRIPTION
Example addresses:
```
0x0014F55A50b281EFD12294f0Cda821Bd8171e920
0x0000000000000000000000000000000000000000
```